### PR TITLE
Remove duplicated key

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ test:
 about:
   home: https://pypi.org/project/lazy_loader/
   summary: Easily load subpackages and functions on demand
-  dev_url: https://github.com/scientific-python/lazy-loader
   license: BSD-3-Clause
   license_file: LICENSE.md
   description: |


### PR DESCRIPTION
xref: https://github.com/scientific-python/lazy_loader/issues/73 and error logs in https://conda-forge.org/status/#version_updates

```
9.00 attempts - The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!

Please check the URLs in your recipe with version '0.3' to make sure they exist!

We also found the following errors:

 - We found a problem parsing the recipe for version '0.3': 

DuplicateKeyError('while constructing a mapping',   in "", line 35, column 3:
      home: https://pypi.org/project/l ... 
      ^ (line: 35), 'found duplicate key "dev_url" with value "https://github.com/scientific-python/lazy_loader" (original value: "https://github.com/scientific-python/lazy-loader")',   in "", line 46, column 3:
      dev_url: https://github.com/scie ... 
      ^ (line: 46), '\n                    To suppress this check see:\n                        http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys\n                    ', '                    Duplicate keys will become an error in future releases, and are errors\n                    by default when using the new API.\n                    ')

traceback:
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/update_recipe/version.py", line 411, in update_version
    cmeta = CondaMetaYAML(raw_meta_yaml)
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/recipe_parser/_parser.py", line 492, in __init__
    self.meta = self._parser.load("".join(lines))
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/main.py", line 426, in load
    return constructor.get_single_data()
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 113, in get_single_data
    return self.construct_document(node)
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 122, in construct_document
    for _dummy in generator:
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1473, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1362, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 144, in construct_object
    data = self.construct_non_recursive_object(node)
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 185, in construct_non_recursive_object
    for _dummy in generator:
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1473, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 1363, in construct_mapping
    if self.check_mapping_key(node, key_node, maptyp, key, value):
  File "/home/runner/micromamba/envs/cf-scripts/lib/python3.10/site-packages/ruamel/yaml/constructor.py", line 275, in check_mapping_key
    raise DuplicateKeyError(*args)
    ```